### PR TITLE
added `repeat` prop

### DIFF
--- a/src/main/FrameTag.ts
+++ b/src/main/FrameTag.ts
@@ -18,4 +18,7 @@ export interface FrameTag {
 
     /** Animation direction. */
     direction: Direction;
+
+    /** Number of times to repeat the animation. `undefined` means loop indefinitely */
+    repeat?: string
 }


### PR DESCRIPTION
This was missing. Frametag has a `repeat` prop. For some reason it's a string.


<img width="469" height="356" alt="image" src="https://github.com/user-attachments/assets/2328322b-90bb-4718-921c-1490f876943b" />
